### PR TITLE
Cancelled to create a new, better, and more organized one.

### DIFF
--- a/easy-mysql.inc
+++ b/easy-mysql.inc
@@ -2189,6 +2189,35 @@ stock SQL::SetIntEntry2(const table[], const field[], value, const column_where[
 	return 1;
 }
 
+stock SQL::SetIntEntry3(const table[], const field[], const field_value[], value, const column_where[] = "", row_identifier = -1, MySQL:connectionhandle = MYSQL_DEFAULT_HANDLE)
+{
+	if(!table[0]) return 0;
+	if(!field[0]) return 0;
+	mysql_format(MySQL:connectionhandle, SQL::upd_form, sizeof(SQL::upd_form), "UPDATE `%s` SET `%s`=`%s`+'%d' WHERE `%s`='%d' ", table, field, field_value, value, column_where, row_identifier);
+	mysql_tquery(MySQL:connectionhandle, SQL::upd_form, "", "");
+	return 1;
+}
+
+stock SQL::SetIntEntry4(const table[], const field[], const field_value[], value, const column_where[] = "", row_identifier = -1, const column_where2[] = "", row_identifier2 = -1, const row_identifier3[] = "", MySQL:connectionhandle = MYSQL_DEFAULT_HANDLE)
+{
+	if(!table[0]) return 0;
+	if(!field[0]) return 0;
+	mysql_format(MySQL:connectionhandle, SQL::upd_form, sizeof(SQL::upd_form), "UPDATE `%s` SET `%s`=`%s`+'%d' WHERE `%s`='%d' ", table, field, field_value, value, column_where, row_identifier);
+	if(!isnull(column_where2) && row_identifier2 != -1 && isnull(row_identifier3))
+	{
+		mysql_format(MySQL:connectionhandle, SQL::upd_form2, sizeof(SQL::upd_form2), " AND `%s`='%d'", column_where2, row_identifier2);
+		strcat(SQL::upd_form, SQL::upd_form2);
+	}
+	if(!isnull(column_where2) && !isnull(row_identifier3) && row_identifier2 == -1)
+	{
+		mysql_format(MySQL:connectionhandle, SQL::upd_form2, sizeof(SQL::upd_form2), " AND `%s`='%s'", column_where2, row_identifier3);
+		strcat(SQL::upd_form, SQL::upd_form2);
+	}
+	strcat(SQL::upd_form, " ");
+	mysql_tquery(MySQL:connectionhandle, SQL::upd_form, "", "");
+	return 1;
+}
+
 stock SQL::SetIntEntryEx(const table[], const field[], value, const column_where[] = "", const row_identifier[] = "", MySQL:connectionhandle = MYSQL_DEFAULT_HANDLE)
 {
 	if(!table[0]) return 0;
@@ -2203,6 +2232,35 @@ stock SQL::SetIntEntryEx2(const table[], const field[], value, const column_wher
 	if(!table[0]) return 0;
 	if(!field[0]) return 0;
 	mysql_format(MySQL:connectionhandle, SQL::upd_form, sizeof(SQL::upd_form), "UPDATE `%s` SET `%s`='%d' WHERE `%s`='%e'", table, field, value, column_where, row_identifier);
+	if(!isnull(column_where2) && !isnull(row_identifier2) && row_identifier3 == -1)
+	{
+		mysql_format(MySQL:connectionhandle, SQL::upd_form2, sizeof(SQL::upd_form2), " AND `%s`='%e'", column_where2, row_identifier2);
+		strcat(SQL::upd_form, SQL::upd_form2);
+	}
+	if(!isnull(column_where2) && row_identifier3 != -1 && isnull(row_identifier2))
+	{
+		mysql_format(MySQL:connectionhandle, SQL::upd_form2, sizeof(SQL::upd_form2), " AND `%s`='%d'", column_where2, row_identifier3);
+		strcat(SQL::upd_form, SQL::upd_form2);
+	}
+	strcat(SQL::upd_form, " ");
+	mysql_tquery(MySQL:connectionhandle, SQL::upd_form, "", "");
+	return 1;
+}
+
+stock SQL::SetIntEntryEx3(const table[], const field[], const field_value[], value, const column_where[] = "", const row_identifier[] = "", MySQL:connectionhandle = MYSQL_DEFAULT_HANDLE)
+{
+	if(!table[0]) return 0;
+	if(!field[0]) return 0;
+	mysql_format(MySQL:connectionhandle, SQL::upd_form, sizeof(SQL::upd_form), "UPDATE `%s` SET `%s`=`%s`+'%d' WHERE `%s`='%e' ", table, field, field_value, value, column_where, row_identifier);
+	mysql_tquery(MySQL:connectionhandle, SQL::upd_form, "", "");
+	return 1;
+}
+
+stock SQL::SetIntEntryEx4(const table[], const field[], const field_value[], value, const column_where[] = "", const row_identifier[] = "", const column_where2[] = "", const row_identifier2[] = "", row_identifier3 = -1, MySQL:connectionhandle = MYSQL_DEFAULT_HANDLE)
+{
+	if(!table[0]) return 0;
+	if(!field[0]) return 0;
+	mysql_format(MySQL:connectionhandle, SQL::upd_form, sizeof(SQL::upd_form), "UPDATE `%s` SET `%s`=`%s`+'%d' WHERE `%s`='%e' ", table, field, field_value, value, column_where, row_identifier);
 	if(!isnull(column_where2) && !isnull(row_identifier2) && row_identifier3 == -1)
 	{
 		mysql_format(MySQL:connectionhandle, SQL::upd_form2, sizeof(SQL::upd_form2), " AND `%s`='%e'", column_where2, row_identifier2);


### PR DESCRIPTION
**Reading a null integer value:**
`SQL::cache_get_value_name_int(row_idx, const column_where[], &dest) `  | **When an integer value is null, the result will be 0**
`SQL::cache_get_value_name(row_idx, const column_where[], dest[], max_len) `  | **When a string value is null the result will be an empty string.**

**Inserting or updating a null string:**
`SQL::WriteString(handle,"TextField", "", .null_value=true);`
`SQL::SetStringEntry("My_Table", "TextField", "", "RegID",register_id, .null_value=true);`
**OR**
`SQL::WriteString(handle,"TextField", MyString, .null_value=(strlen(MyString) ? false : true));`
`SQL::SetStringEntry("My_Table", "TextField", MyString, "RegID",Register_ID, .null_value=(strlen(MyString) ? false : true));`

**Inserting or updating a null integer value:**
`SQL::WriteInt(handle,"IntField", 0, .null_value=true);`
`SQL::SetIntEntry("My_Table", "IntField", 0, "RegID",register_id, .null_value=true);`
**OR**
`SQL::WriteInt(handle,"IntField", MyIntVar, .null_value=(MyIntVar ? false : true));`
`SQL::SetIntEntry("My_Table", "IntField", MyIntVar, "RegID",Register_ID, .null_value=(MyIntVar ? false : true));`


**Everything has been tested and is working correctly!**

**I apologize for all these commits until I got to this one, which will be the final one.**

The first method I used works, but it requires work to ensure that no string contains NULL by mistake or that no integer value contains -65535.

With the `bool:null_value` parameter, everything is resolved and becomes simple.